### PR TITLE
Update Gemfile to match Listing 1.5

### DIFF
--- a/hello_app/Gemfile
+++ b/hello_app/Gemfile
@@ -21,9 +21,5 @@ group :development do
   gem 'spring-watcher-listen', '2.0.0'
 end
 
-group :production do
-  gem 'pg', '0.18.4'
-end
-
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]


### PR DESCRIPTION
Near the end of https://www.railstutorial.org/book/beginning#sec-bundler 

The Gemfile in `Listing 1.5` doesn't include 

    group :production do
      gem 'pg', '0.18.4'
    end

These lines are added in `Listing 1.14`